### PR TITLE
feat: dockerfile에 yarn build 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ RUN yarn install --frozen-lockfile
 
 COPY . .
 
+RUN yarn build
+
 EXPOSE 3000
 
 ENTRYPOINT ["yarn", "start:prod"]


### PR DESCRIPTION
yarn start:prod를 실행하려면 dist폴더가 필요하다고 한다
dist 폴더는 build 과정을 거치면 생성된다고 하여
RUN yarn build를 추가했다.